### PR TITLE
Added white space to test line

### DIFF
--- a/configure
+++ b/configure
@@ -40,7 +40,7 @@ fi
 mkdir -p SITK
 (
     cd SITK &&
-    [-d SimpleITK ] ||
+    [ -d SimpleITK ] ||
       ( git clone  ${SimpleITKGit} &&
           cd SimpleITK &&
           git checkout  ${SITKTAG} ) || exit 1


### PR DESCRIPTION
The check for an existing SimpleITK directory was giving an error due to missing space in the test call