### PR TITLE
Explicit compiler flags for cmake

### DIFF
--- a/configure
+++ b/configure
@@ -40,7 +40,7 @@ fi
 mkdir -p SITK
 (
     cd SITK &&
-    [-d SimpleITK ] ||
+    [ -d SimpleITK ] ||
       ( git clone  ${SimpleITKGit} &&
           cd SimpleITK &&
           git checkout  ${SITKTAG} ) || exit 1
@@ -57,6 +57,8 @@ mkdir -p SITK
         -DWRAP_CSHARP=OFF \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_TESTING=OFF \
+        -DCMAKE_CXX_COMPILER=${CXX} \
+        -DCMAKE_C_COMPILER=${CC} \
         ../SimpleITK/SuperBuild/ ||
     exit 1
 


### PR DESCRIPTION
Cmake under OSX often finds a version of the compilers deep inside
the xcode installation, even if the first version in the path
is in /usr/bin and the CXX/CC environment variables are set.
The configure script for PCRE has issues with the long paths.

This patch explictly sets the compilers using the -DCMAKE_ options.
