### PR TITLE
Support for testing the SimpleITK R package and installer using Circl…

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,57 @@
+machine:
+        pre:
+          - sudo apt-get -y install software-properties-common
+          - sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu trusty/"
+          - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+          - sudo apt-get update
+          - sudo apt-get -y install r-base-dev
+          - sudo apt-get -y install libssh2-1-dev
+          - sudo service postgresql stop
+          - sudo service mysql stop
+          - mkdir -p ${HOME}/Rlibs
+          - mkdir -p ${HOME}/.ssh_tmp
+        environment:
+          R_LIBS: /home/ubuntu/Rlibs
+          ExternalData_OBJECT_STORES: ${HOME}/.ExternalData
+          SIMPLEITK_BUILD_DIR: ${HOME}/SimpleITKRInstaller/SITK
+          CMAKE_DOWNLOAD_FILE: cmake-3.6.0-Linux-x86_64.sh
+          ITK_REPOSITORY: ${ExternalData_OBJECT_STORES}/ITK.git
+          DISTCC_TCP_CORK: "0"
+          DISTCC_DIR: ${HOME}/.distcc
+          MAKE_J: $(expr $CIRCLE_NODE_TOTAL + 1)
+          SITK_NOSHOW: "1"
+          LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}:${SIMPLEITK_BUILD_DIR}/Build/ITK-build/lib/:${SIMPLEITK_BUILD_DIR}/Build/SimpleITK-build/lib/
+        post:
+           - sudo apt-get remove cmake && sudo apt-get install distcc
+           - sudo service mysql stop
+           - sudo service postgresql stop 
+           - sudo sed -i.bak s/STARTDISTCC=\"false\"/STARTDISTCC=\"true\"/g /etc/default/distcc && sudo /etc/init.d/distcc start
+           - mkdir -p "${DISTCC_DIR}" && printf -- "localhost/1 --localslots=1\n" > "${DISTCC_DIR}/hosts" && for ((i=1;i<CIRCLE_NODE_TOTAL;i++)); do printf "ubuntu@node$i/2\n" >> "${DISTCC_DIR}/hosts"; done
+           - mkdir -p "${ExternalData_OBJECT_STORES}"
+           - cd ${ExternalData_OBJECT_STORES} && if [[ ! -e ${CMAKE_DOWNLOAD_FILE} ]]; then curl -sSO https://cmake.org/files/v3.6/${CMAKE_DOWNLOAD_FILE}; fi
+           - echo "y\n" | sudo bash "${ExternalData_OBJECT_STORES}/${CMAKE_DOWNLOAD_FILE}" --prefix=/usr/local --exclude-subdir
+           - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then mkdir -p .ssh && printf -- "Host *\nControlMaster auto\nControlPath ~/.ssh_tmp/master-%%r@%%h:%%p\n" >> .ssh/config ; fi
+
+dependencies:
+    cache_directories:
+        - "~/.ExternalData"
+        - "~/Rlibs"
+    pre:
+        - cd ${ExternalData_OBJECT_STORES} && if [[ ! -e ${ITK_REPOSITORY} ]]; then git clone --bare https://ITK.org/ITK.git; fi && cd ${ITK_REPOSITORY} && git fetch origin
+    post:
+        - mkdir -p "${DISTCC_DIR}" && printf -- "--randomize localhost/1 --localslots=1\n" > "${DISTCC_DIR}/hosts" && for ((i=1;i<CIRCLE_NODE_TOTAL;i++)); do printf "ubuntu@node$i/2\n" >> "${DISTCC_DIR}/hosts"; done
+        - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then find ${SIMPLEITK_BUILD_DIR} -name \*.o -delete && rm -rf ${SIMPLEITK_BUILD_DIR}/ITK ${SIMPLEITK_BUILD_DIR}/ITK-build; fi
+    override:
+      - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then for ((i=1;i<CIRCLE_NODE_TOTAL;i++)); do ssh -fMN ubuntu@node$i; done ; fi
+      - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then R -q --no-save --file=/home/ubuntu/SimpleITKRInstaller/circleci_R_commands.R; fi
+test:
+    pre:
+      - if [ $CIRCLE_NODE_INDEX -ne 0 ]; then rsync -ravz -e ssh ubuntu@node0:${SIMPLEITK_BUILD_DIR}/ ${SIMPLEITK_BUILD_DIR} && rsync -ravz -e ssh ubuntu@node0:${ExternalData_OBJECT_STORES} ${ExternalData_OBJECT_STORES}; fi:
+          parallel: true
+    override:
+        - ctest -j 2 -I ${CIRCLE_NODE_INDEX},,${CIRCLE_NODE_TOTAL}:
+            parallel: true
+            pwd: SITK/Build/SimpleITK-build
+            environment:
+                ITK_GLOBAL_DEFAULT_NUMBER_OF_THREAD: 2
+                CTEST_OUTPUT_ON_FAILURE: 1      

--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ dependencies:
       - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then R -q --no-save --file=/home/ubuntu/SimpleITKRInstaller/circleci_R_commands.R; fi
 test:
     pre:
-      - if [ $CIRCLE_NODE_INDEX -ne 0 ]; then rsync  -ravz -e ssh ubuntu@node0:${ExternalData_OBJECT_STORES} ${HOME} && rsync -ravz -e ssh ubuntu@node0:${SIMPLEITK_BUILD_DIR}/ ${SIMPLEITK_BUILD_DIR}  fi:
+      - if [ $CIRCLE_NODE_INDEX -ne 0 ]; then rsync  -ravz -e ssh ubuntu@node0:${ExternalData_OBJECT_STORES} ${HOME} && rsync -ravz -e ssh ubuntu@node0:${SIMPLEITK_BUILD_DIR}/ ${SIMPLEITK_BUILD_DIR} ; fi:
           parallel: true
     override:
         - ctest -j 2 -I ${CIRCLE_NODE_INDEX},,${CIRCLE_NODE_TOTAL}:

--- a/circle.yml
+++ b/circle.yml
@@ -46,7 +46,7 @@ dependencies:
       - if [ $CIRCLE_NODE_INDEX -eq 0 ]; then R -q --no-save --file=/home/ubuntu/SimpleITKRInstaller/circleci_R_commands.R; fi
 test:
     pre:
-      - if [ $CIRCLE_NODE_INDEX -ne 0 ]; then rsync -ravz -e ssh ubuntu@node0:${SIMPLEITK_BUILD_DIR}/ ${SIMPLEITK_BUILD_DIR} && rsync -ravz -e ssh ubuntu@node0:${ExternalData_OBJECT_STORES} ${ExternalData_OBJECT_STORES}; fi:
+      - if [ $CIRCLE_NODE_INDEX -ne 0 ]; then rsync  -ravz -e ssh ubuntu@node0:${ExternalData_OBJECT_STORES} ${HOME} && rsync -ravz -e ssh ubuntu@node0:${SIMPLEITK_BUILD_DIR}/ ${SIMPLEITK_BUILD_DIR}  fi:
           parallel: true
     override:
         - ctest -j 2 -I ${CIRCLE_NODE_INDEX},,${CIRCLE_NODE_TOTAL}:

--- a/circleci_R_commands.R
+++ b/circleci_R_commands.R
@@ -28,7 +28,7 @@ Sys.setenv(CC = paste("distcc", CC),
            CXX= paste("distcc", CXX),
            RTESTON="ON",
            MAKEJ=makej,
-#           DSHARED_LIB="-DBUILD_SHARED_LIBS:BOOL=ON",
+           DSHARED_LIB="-DBUILD_SHARED_LIBS:BOOL=ON",
            DITK_REPOSITORY=paste0("-DITK_REPOSITORY=", ITKREPO))
 ## Just in case we're borderline on RAM later on
 gc()

--- a/circleci_R_commands.R
+++ b/circleci_R_commands.R
@@ -28,7 +28,7 @@ Sys.setenv(CC = paste("distcc", CC),
            CXX= paste("distcc", CXX),
            RTESTON="ON",
            MAKEJ=makej,
-           DSHARED_LIB="-DBUILD_SHARED_LIBS:BOOL=ON",
+#           DSHARED_LIB="-DBUILD_SHARED_LIBS:BOOL=ON",
            DITK_REPOSITORY=paste0("-DITK_REPOSITORY=", ITKREPO))
 ## Just in case we're borderline on RAM later on
 gc()

--- a/circleci_R_commands.R
+++ b/circleci_R_commands.R
@@ -1,0 +1,35 @@
+## Placing the R commands in a script as it gets too messy
+## to do it all on the command line
+
+if (!require(devtools)) {
+  ## devtools install
+  install.packages("devtools", lib="~/Rlibs", repo="http://cloud.r-project.org/")
+  ## Just in case we're borderline on RAM later on
+}
+makej <- as.numeric(Sys.getenv("MAKE_J"))
+# deal with missing entries
+makej <- max(makej, 1, na.rm=TRUE)
+
+## get the CC and CXX settings so we can set up distcc
+RCMD <- file.path(R.home("bin"), "R")
+args <- paste("--no-site-file", "--no-environ", "--no-save", 
+        "--no-restore", "--quiet", "CMD", "config", collapse=" ")
+argscc <- paste(RCMD, args, "CC", collapse=" ")
+argscxx <- paste(RCMD, args, "CXX", collapse=" ")
+
+CC <- system(argscc, intern=TRUE)
+CXX <- system(argscxx, intern=TRUE)
+
+
+ITKREPO <- Sys.getenv("ITK_REPOSITORY")
+# with distcc it gets too complicated to deal with all the quoting, so
+# pass CC and CXX via environment
+Sys.setenv(CC = paste("distcc", CC),
+           CXX= paste("distcc", CXX),
+           RTESTON="ON",
+           MAKEJ=makej,
+           DSHARED_LIB="-DBUILD_SHARED_LIBS:BOOL=ON",
+           DITK_REPOSITORY=paste0("-DITK_REPOSITORY=", ITKREPO))
+## Just in case we're borderline on RAM later on
+gc()
+devtools::install("/home/ubuntu/SimpleITKRInstaller")

--- a/configure
+++ b/configure
@@ -7,8 +7,9 @@
 # Requires git and cmake
 #
 export SimpleITKGit=https://github.com/SimpleITK/SimpleITK
+export SimpleITKGit=https://github.com/richardbeare/SimpleITK
 export SITKTAG=v0.10.0
-export SITKTAG=master
+export SITKTAG=820b1d85194b99c84095f7f8734da4c19a4db558
 
 export PKGBASED=$(pwd)
 echo ${PKGBASED}

--- a/configure
+++ b/configure
@@ -17,24 +17,27 @@ echo ${PKGBASED}
 RCALL="${R_HOME}/bin/R"
 export RCALL
 
-CC="$(${RCALL} CMD config CC)"
-CXX="$(${RCALL} CMD config CXX)"
-CFLAGS="$(${RCALL} CMD config CFLAGS)"
-CXXFLAGS="$(${RCALL} CMD config CXX1XFLAGS)"
-CPPFLAGS="$(${RCALL} CMD config CPPFLAGS)"
+CC=${CC:-$(${RCALL} CMD config CC)}
+CXX=${CXX:-$(${RCALL} CMD config CXX)}
+CFLAGS=${CFLAGS:-$(${RCALL} CMD config CFLAGS)}
+CXXFLAGS=${CXXFLAGS:-$(${RCALL} CMD config CXX1XFLAGS)}
+CPPFLAGS=${CPPFLAGS:-$(${RCALL} CMD config CPPFLAGS)}
 export CXX
 export CC
 export CXXFLAGS
 export CPPFLAGS
 export CFLAGS
 
+
+RTESTON=${RTESTON:-OFF}
+export RTESTON
 ## Level of parallel build
 ## Don't use the Ncpus option for install.packages because it
 ## refers to multiple packages
-if [ -z "${MAKEJ}" ] ; then
-    MAKEJ=1
-    export MAKEJ
-fi
+MAKEJ=${MAKEJ:-1}
+export MAKEJ
+
+
 
 ## All the building is going to happen in an SITK folder
 mkdir -p SITK
@@ -56,7 +59,9 @@ mkdir -p SITK
         -DWRAP_JAVA=OFF \
         -DWRAP_CSHARP=OFF \
         -DBUILD_EXAMPLES=OFF \
-        -DBUILD_TESTING=OFF \
+        -DBUILD_TESTING=${RTESTON} \
+        ${DSHARED_LIB} \
+	${DITK_REPOSITORY} \
         ../SimpleITK/SuperBuild/ ||
     exit 1
 

--- a/configure
+++ b/configure
@@ -8,6 +8,7 @@
 #
 export SimpleITKGit=https://github.com/SimpleITK/SimpleITK
 export SITKTAG=v0.10.0
+export SITKTAG=master
 
 export PKGBASED=$(pwd)
 echo ${PKGBASED}


### PR DESCRIPTION
…eCI facilities.

The circle.yml file contains various configuration options used by CircleCI, including
setting up R from the CRAN repo, installing an up to date version of cmake and
creating ssh connections to other nodes.

The build process for SimpleITK is very compute intensive and uses distcc to
run compilations on other nodes. Shared libraries are enabled to reduce
RAM requirements when linking. Failures due to 4GB limits are common
otherwise.

Testing is also distributed across multiple nodes.
