### PR TITLE
Option for additional cmake flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ These tricks require _devtools_ to be installed from github (as of June 2017).
 Additional cmake can be passed as follows. Multiple arguments should be
 separated by an escaped semicolon (\;).
 ```R
-devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars="MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON:-DSimpleITK_GIT_PROTOCOL=https"'))
+devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars=MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON\\;-DSimpleITK_GIT_PROTOCOL=https'))
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ Requires _cmake_ and _git_ in the path.
 
 Tested on Linux and Mac.
 
-These tricks require _devtools_ to be installed from github (as of June 2017).
+**These tricks require _devtools_ to be installed from github (as of June 2017).**
 
 Additional cmake can be passed as follows. Multiple arguments should be
-separated by an escaped semicolon (\;).
+separated by an escaped space. Note that the space preceeding "CMAKE_EXTRA_FLAGS" should not be escaped.
+
 ```R
-devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars=MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON\\;-DSimpleITK_GIT_PROTOCOL=https'))
+devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars=MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON\\ -DSimpleITK_GIT_PROTOCOL=https'))
+```
+or, enable some IO modules:
+
+```R
+devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars=MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON\\ -DModule_MGHIO=ON\\ -DModule_ITKIOMINC=ON'))
 ```

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Requires _cmake_ and _git_ in the path.
 
 Tested on Linux and Mac.
 
+These tricks require _devtools_ to be installed from github (as of June 2017).
+
 Additional cmake can be passed as follows. Multiple arguments should be
-separated by a colon (:), and quotes need to be escaped. There seems
-to be processing of whitespace somewhere in the layers of devtools that
-make it difficult to escape the spaces.
+separated by an escaped semicolon (\;).
 ```R
-devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars="MAKEJ=6 CMAKE_EXTRA_FLAGS=\"-DSimpleITK_4D_IMAGES=ON:-DSimpleITK_GIT_PROTOCOL=https\" "'))
+devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars="MAKEJ=6 CMAKE_EXTRA_FLAGS=-DSimpleITK_4D_IMAGES=ON:-DSimpleITK_GIT_PROTOCOL=https"'))
 ```

--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Requires _cmake_ and _git_ in the path.
 
 Tested on Linux and Mac.
 
+Additional cmake can be passed as follows. Multiple arguments should be
+separated by a colon (:), and quotes need to be escaped. There seems
+to be processing of whitespace somewhere in the layers of devtools that
+make it difficult to escape the spaces.
+```R
+devtools::install_github("SimpleITK/SimpleITKRInstaller",args=c('--configure-vars="MAKEJ=6 CMAKE_EXTRA_FLAGS=\"-DSimpleITK_4D_IMAGES=ON:-DSimpleITK_GIT_PROTOCOL=https\" "'))
+```

--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ MAKEJ=${MAKEJ:-1}
 export MAKEJ
 
 ## Get rid of the colons
-CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//:/ }
+CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//;/ }
 
 cmake $CMAKE_EXTRA_FLAGS \
         -DWRAP_DEFAULT=OFF\

--- a/configure
+++ b/configure
@@ -35,14 +35,7 @@ MAKEJ=${MAKEJ:-1}
 export MAKEJ
 
 ## Get rid of the colons
-CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//;/ }
-
-cmake $CMAKE_EXTRA_FLAGS \
-        -DWRAP_DEFAULT=OFF\
-        -DWRAP_R=ON \
-        -DBUILD_EXAMPLES=OFF \
-        -DBUILD_TESTING=OFF \
-        ../SimpleITK/SuperBuild/
+export CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//;/ }
 
 ## All the building is going to happen in an SITK folder
 mkdir -p SITK

--- a/configure
+++ b/configure
@@ -31,10 +31,18 @@ export CFLAGS
 ## Level of parallel build
 ## Don't use the Ncpus option for install.packages because it
 ## refers to multiple packages
-if [ -z "${MAKEJ}" ] ; then
-    MAKEJ=1
-    export MAKEJ
-fi
+MAKEJ=${MAKEJ:-1}
+export MAKEJ
+
+## Get rid of the colons
+CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//:/ }
+
+cmake $CMAKE_EXTRA_FLAGS \
+        -DWRAP_DEFAULT=OFF\
+        -DWRAP_R=ON \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_TESTING=OFF \
+        ../SimpleITK/SuperBuild/
 
 ## All the building is going to happen in an SITK folder
 mkdir -p SITK
@@ -47,7 +55,7 @@ mkdir -p SITK
 
     mkdir -p Build &&
     cd Build &&
-    cmake \
+    cmake $CMAKE_EXTRA_FLAGS \
         -DWRAP_DEFAULT=OFF\
         -DWRAP_R=ON \
         -DBUILD_EXAMPLES=OFF \

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 # configure script that will fetch and build SimpleITK, then move the results
 # to somewhere that R can install. It takes a long time and uses
@@ -34,8 +34,7 @@ export CFLAGS
 MAKEJ=${MAKEJ:-1}
 export MAKEJ
 
-## Get rid of the colons
-export CMAKE_EXTRA_FLAGS=${CMAKE_EXTRA_FLAGS//;/ }
+[ -n "$CMAKE_EXTRA_FLAGS" ] && echo "Extra flags for cmake: $CMAKE_EXTRA_FLAGS"
 
 ## All the building is going to happen in an SITK folder
 mkdir -p SITK


### PR DESCRIPTION
Added options to support passing extra flags to cmake. Adopted a colon separated list approach because devtools appears to be too clever about splitting arguments before passing them on. Open to better suggestions. Probably should add an example of passing a flag to the ITK build, such as turning on a remote module.