### PR TITLE
Change CXX1X flag to CXX11.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
              R -e 'install.packages("devtools", repo="http://cloud.r-project.org/")'
       - run:
           name: Build SimpleITK R Package
-          no_output_timeout: 20.0m
+          no_output_timeout: 30.0m
           environment:
              MAKEJ: 4
              RTESTON: ON

--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@ export RCALL
 CC="$(${RCALL} CMD config CC)"
 CXX="$(${RCALL} CMD config CXX)"
 CFLAGS="$(${RCALL} CMD config CFLAGS)"
-CXXFLAGS="$(${RCALL} CMD config CXX1XFLAGS)"
+CXXFLAGS="$(${RCALL} CMD config CXX11FLAGS)"
 CPPFLAGS="$(${RCALL} CMD config CPPFLAGS)"
 export CXX
 export CC


### PR DESCRIPTION
The CXX1X was a legacy form that has been removed. The CXX1X form
was officially deprecated in R 3.4.4 and support for CXX11 was
included in 3.4.0. There should be no need for SimpleITK to
support the old form.