### PR TITLE
Setting environment variables change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ devtools::install_github("SimpleITK/SimpleITKRInstaller")
 or, turn on mutlicore compilation using
 
 ```R
-devtools::install_github("SimpleITK/SimpleITKRInstaller", args=c("--configure-vars=MAKEJ=6"))
+devtools::install_github("SimpleITK/SimpleITKRInstaller", configure.vars=c("MAKEJ=6"))
 ```
 
 Requires _cmake_ and _git_ in the path.


### PR DESCRIPTION
The devtools install_github command no longer supports the "args" parameter. The same effect is achieved by setting the "configure.vars" parameter.