### PR TITLE
add SuperElastix to build

### DIFF
--- a/configure
+++ b/configure
@@ -57,6 +57,7 @@ mkdir -p SITK
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DITK_USE_BUILD_DIR:BOOL=ON \
+        -DSimpleITK_USE_ELASTIX=ON \
         ${SITK_SRC}/SuperBuild/ ||
     exit 1
 


### PR DESCRIPTION
Dear all, 

My impression is that adding SuperElastix to build does not extend much the already lengthy build process. However, I observe that many use Elastix along with SimpleITK, specifically with ElastixImageFilter. 

For now I added `SimpleITK_USE_ELASTIX=ON` to build but I am also open to make this optional and callable from `configure.vars`. 

Also, as I have tried to use functions, `ReadParameterFile` is for example not among exported objects although one can call it with `:::` and it is accessible in the python wrapper.   

Happy to take suggestions. 