### PR TITLE
Allow users to enable additional modules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,26 @@
 
 A [remotes](https://github.com/r-lib/remotes) based installer for SimpleITK in [R](https://www.r-project.org/).
 
+Default configuration, single core compilation:
+
 ```R
 remotes::install_github("SimpleITK/SimpleITKRInstaller")
 ```
-or, turn on mutlicore compilation using
+
+Turn on mutlicore compilation, six cores in this example
 
 ```R
 remotes::install_github("SimpleITK/SimpleITKRInstaller", configure.vars=c("MAKEJ=6"))
 ```
+
+Use multicore compilation and build additional modules not included in the default build setup such as SimpleElastix (registration) and DCMTK (additional DICOM IO option beyond the default GDCM).
+
+**Note**: We need to use backslashes to escape the spaces in the `ADDITIONAL_SITK_MODULES` otherwise the `remotes::install` does not pass the string correctly to the shell (separates it using the spaces instead of passing as one string).
+
+```R
+remotes::install_github("SimpleITK/SimpleITKRInstaller", configure.vars=c("MAKEJ=6", "ADDITIONAL_SITK_MODULES=-DSimpleITK_USE_ELASTIX=ON\\  -DModule_ITKIODCMTK:BOOL=ON"))
+```
+
 
 Requires _cmake_ and _git_ in the path.
 

--- a/configure
+++ b/configure
@@ -57,6 +57,7 @@ mkdir -p SITK
         -DBUILD_TESTING=OFF \
         -DCMAKE_BUILD_TYPE=MinSizeRel \
         -DITK_USE_BUILD_DIR:BOOL=ON \
+        ${ADDITIONAL_SITK_MODULES} \
         ${SITK_SRC}/SuperBuild/ ||
     exit 1
 


### PR DESCRIPTION
Allow the user to specify additional, non default, modules that will be built as part of the local SimpleITK build.