### PR TITLE
Update mac runners.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         R: [ '4.3.1', '4.4.1' ]
-        os: [ 'macos-13', 'ubuntu-latest' ]
+        os: [ 'macos-15-intel', 'macos-latest', 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.R }} ${{ matrix.os }} build
     env:


### PR DESCRIPTION
macos-latest is arm64 architecture and macos-15-intel is the last available intel architecture.