### PR TITLE
Update CircleCI workflow, setting environment var.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           no_output_timeout: 30m
           command: |
             set -x
-            R -e "remotes::install_git(c('.'), lib=c('${R_LIBS}'), configure.vars=c('MAKEJ=3'))"
+            R -e "Sys.setenv(MAKEJ=3); remotes::install_git(c('.'), lib=c('${R_LIBS}'))"
 
 workflows:
   r-build-test:


### PR DESCRIPTION
Instead of passing via configure.vars, explicitly set the environment variables prior to calling remotes::install_git. This approach works across all three major operating systems. Using the configure.vars did not work on windows.