### PR TITLE
Change build command from make to cmake.

### DIFF
--- a/configure
+++ b/configure
@@ -65,7 +65,7 @@ mkdir -p SITK
     exit 1
 
     echo "Parallel build using -j${MAKEJ}"
-    make -j${MAKEJ} SimpleITK-build && \
+    cmake --build . --target SimpleITK-build -- -j${MAKEJ} && \
         rm -rf ITK-build &&
     # Use R to do the move to avoid system specific issues.
     ${RCALL} -f ${PKGBASED}/sitkmove.R --args SimpleITK-build/Wrapping/R/Packaging/SimpleITK/ ${PKGBASED} ||


### PR DESCRIPTION
Use CMake instead of Make for the build step so
that it is independent of the generator (Makefile, Ninja etc.) and is consistent across all operating systems.