### PR TITLE
Support arbitrary SimpleITK versions.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,11 @@
 Package: SimpleITK
-Version: 2.5.3
-Date: 2025-11-20
+SITK_TARGET: v2.5.4
+Note1: The Version and Date fields are derived from the SITK_TARGET 
+       DO NOT EDIT THEM MANUALLY. 
+       After updating the SITK_TARGET run the sitk_r_version_date.sh script
+       and it will update these fields according to the SITK_TARGET.
+Version: 2.5.4
+Date: 2026-04-22
 Title: SimpleITK: A Simplified Interface to the Insight Toolkit
 Authors@R: c(person("Richard", "Beare", role = c("aut", "cre"),
                       email = "Richard.Beare@ieee.org"),
@@ -16,7 +21,7 @@ Description: This package is an interface to SimpleITK, which is a simplified
      interface to the Insight Toolkit (ITK) for medical image segmentation
      and registration.
 License: Apache License 2.0
-Note: The first url in the URL field below is the SimpleITK repository, and is used
+Note2: The first url in the URL field below is the SimpleITK repository, and is used
      by the config script under the assumption that it is the first in the list.
 URL: https://github.com/SimpleITK/SimpleITK, https://www.simpleitk.org, https://www.itk.org
 BugReports: https://github.com/SimpleITK/SimpleITK/issues

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ On Windows requires [rtools](https://cran.r-project.org/bin/windows/Rtools/) ins
 ```R
 Sys.setenv(RTOOLS_HOME = "C:/rtools45")
 ```
+# Building a specific SimpleITK version
+
+If you want to create a custom build for a specific SimpleITK release or a development version you need to:
+1. Set the `SITK_TARGET` in the `DESCRIPTION` file to the appropriate committish (hash, tag or branch).
+2. Run the `sitk_r_version_date.sh` script which will update the `Version` and `Date` entries in the `DESCRIPTION` file to match the expected format. For Version this is MAJOR.MINOR.PATCH.[9000] where the last entry is an "R universe" convention denoting "in development".
 
 # How to Cite
 

--- a/configure
+++ b/configure
@@ -7,10 +7,7 @@
 # Requires git and cmake
 #
 export SimpleITKGit=$(Rscript -e "d <- desc::desc(file='DESCRIPTION'); urls <- strsplit(d\$get_field('URL'), ',')[[1]]; cat(trimws(urls[1]))")
-export SITKTAG=v$(Rscript -e "cat(desc::desc_get_field('Version', file='DESCRIPTION'))")
-# TODO: parse SITKTAG from DESCRIPTION after new release
-# export SITKTAG=v$(Rscript -e "cat(desc::desc_get_field('Version', file='DESCRIPTION'))")
-export SITKTAG='1899b2'
+export SITK_TARGET=$(Rscript -e "cat(desc::desc_get_field('SITK_TARGET', file='DESCRIPTION'))")
 
 export PKGBASED=$(pwd)
 echo ${PKGBASED}
@@ -43,10 +40,13 @@ fi
 mkdir -p SITK
 (
     cd SITK &&
-    [ -d SimpleITK ] ||
-      ( git clone  ${SimpleITKGit} &&
-          cd SimpleITK &&
-          git checkout  ${SITKTAG} ) || exit 1
+    if [ ! -d SimpleITK ]; then
+        git clone ${SimpleITKGit} || exit 1
+    fi
+    cd SimpleITK &&
+    git fetch --tags &&
+    git checkout ${SITK_TARGET} || exit 1
+    cd ..
 
     SITK_SRC=$(pwd)/SimpleITK
 

--- a/configure.win
+++ b/configure.win
@@ -11,9 +11,7 @@ set -e
 # --- Settings ---
 # Load shared configuration for all OS (SimpleITK repository URL and tag)
 export SimpleITKGit=$(Rscript -e "d <- desc::desc(file='DESCRIPTION'); urls <- strsplit(d\$get_field('URL'), ',')[[1]]; cat(trimws(urls[1]))")
-# TODO: parse SITKTAG from DESCRIPTION after new release
-# export SITKTAG=v$(Rscript -e "cat(desc::desc_get_field('Version', file='DESCRIPTION'))")
-export SITKTAG='1899b2'
+export SITK_TARGET=$(Rscript -e "cat(desc::desc_get_field('SITK_TARGET', file='DESCRIPTION'))")
 
 PKGBASED=$(pwd)
 echo "$PKGBASED"
@@ -68,11 +66,11 @@ export MAKEJ
   if [ ! -d SimpleITK ]; then
     git clone "$SimpleITKGit"
     cd SimpleITK
-    git checkout "$SITKTAG"
+    git checkout "$SITK_TARGET"
   else
     cd SimpleITK
     git fetch --tags
-    git checkout "$SITKTAG"
+    git checkout "$SITK_TARGET"
   fi
 
   SITK_SRC="$(pwd)"

--- a/sitk_r_version_date.sh
+++ b/sitk_r_version_date.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env sh
+# sitk_r_version_date.sh - Update the Version and Date fields in DESCRIPTION
+# based on the SITK_TARGET field.
+#
+# Run this script manually after changing the SITK_TARGET field in DESCRIPTION:
+#   sh sitk_r_version_date.sh
+#
+# The script reads SITK_TARGET and the SimpleITK repository URL from DESCRIPTION,
+# does a minimal blobless clone to a temporary directory to resolve the tag/commit,
+# derives an R-compatible Version (MAJOR.MINOR.PATCH[.9000]) and the commit Date,
+# then writes both back into DESCRIPTION.
+#
+# R version convention: MAJOR.MINOR.PATCH[.9000] where .9000 indicates a
+# development/pre-release build per https://r-pkgs.org/lifecycle.html#dev-version.
+# SimpleITK tags with non-numeric suffixes (rc, a, b, b0x, etc.) and non-numeric
+# tags (va01, latest) are mapped to nearest numeric prefix + .9000 or 0.0.0.9000.
+#
+# Requires: git, sed, awk
+
+set -e
+
+PKGBASED="$(cd "$(dirname "$0")" && pwd)"
+DESCRIPTION="${PKGBASED}/DESCRIPTION"
+
+if [ ! -f "${DESCRIPTION}" ]; then
+    echo "ERROR: DESCRIPTION not found at ${DESCRIPTION}" >&2
+    exit 1
+fi
+
+SITK_TARGET=$(grep '^SITK_TARGET:' "${DESCRIPTION}" | awk '{print $2}')
+SITK_GIT=$(grep '^URL:' "${DESCRIPTION}" | sed 's/URL: *//' | cut -d',' -f1 | tr -d ' ')
+
+if [ -z "${SITK_TARGET}" ]; then
+    echo "ERROR: SITK_TARGET field not found in DESCRIPTION" >&2
+    exit 1
+fi
+if [ -z "${SITK_GIT}" ]; then
+    echo "ERROR: URL field not found in DESCRIPTION" >&2
+    exit 1
+fi
+
+echo "SITK_TARGET: ${SITK_TARGET}"
+echo "Cloning ${SITK_GIT} (blobless) ..."
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+git clone --filter=blob:none --no-checkout "${SITK_GIT}" "${TMPDIR}/SimpleITK"
+cd "${TMPDIR}/SimpleITK"
+git fetch --tags
+git checkout "${SITK_TARGET}"
+
+SITK_SRC="${TMPDIR}/SimpleITK"
+
+# Derive R-compatible Version from the checked-out commit/tag.
+ACTUAL_TAG=$(git -C "${SITK_SRC}" describe --tags --exact-match 2>/dev/null || true)
+if [ -n "${ACTUAL_TAG}" ]; then
+    # Exact tag: strip leading 'v', then strip any non-numeric pre-release suffix.
+    # e.g. v2.5.0rc1->2.5.0.9000, v3.0.0a1->3.0.0.9000, v0.3.0b->0.3.0.9000, v2.5.3->2.5.3
+    RAW=$(echo "${ACTUAL_TAG}" | sed 's/^v//')
+    STRIPPED=$(echo "${RAW}" | sed 's/\([0-9][0-9]*\(\.[0-9][0-9]*\)*\)[^0-9.].*/\1/')
+    if [ -z "${STRIPPED}" ] || ! echo "${STRIPPED}" | grep -qE '^[0-9]+(\.[0-9]+)*$'; then
+        R_VERSION="0.0.0.9000"
+    elif [ "${RAW}" = "${STRIPPED}" ]; then
+        R_VERSION="${STRIPPED}"
+    else
+        R_VERSION="${STRIPPED}.9000"
+    fi
+else
+    # Not on an exact tag.
+    # First preference: a future tag (HEAD is an ancestor of the tag) — building toward it.
+    # git describe --contains output is "TAG~N" or "TAG^0~N"; strip from first ~ or ^.
+    FUTURE_TAG=$(git -C "${SITK_SRC}" describe --tags --contains HEAD 2>/dev/null | head -n 1 | sed 's/[~^].*//' || true)
+    if [ -n "${FUTURE_TAG}" ]; then
+        BASE=$(echo "${FUTURE_TAG}" | sed 's/^v//')
+        STRIPPED=$(echo "${BASE}" | sed 's/\([0-9][0-9]*\(\.[0-9][0-9]*\)*\)[^0-9.].*/\1/')
+        if [ -n "${STRIPPED}" ] && echo "${STRIPPED}" | grep -qE '^[0-9]+(\.[0-9]+)*$'; then
+            R_VERSION="${STRIPPED}.9000"
+        else
+            R_VERSION="0.0.0.9000"
+        fi
+    else
+        # Second preference: nearest ancestor tag.
+        BASE=$(git -C "${SITK_SRC}" describe --tags 2>/dev/null | sed 's/-[0-9]*-g[0-9a-f]*//' | sed 's/^v//' || true)
+        if [ -n "${BASE}" ]; then
+            STRIPPED=$(echo "${BASE}" | sed 's/\([0-9][0-9]*\(\.[0-9][0-9]*\)*\)[^0-9.].*/\1/')
+            if [ -n "${STRIPPED}" ] && echo "${STRIPPED}" | grep -qE '^[0-9]+(\.[0-9]+)*$'; then
+                R_VERSION="${STRIPPED}.9000"
+            else
+                R_VERSION="0.0.0.9000"
+            fi
+        else
+            R_VERSION="0.0.0.9000"
+        fi
+    fi
+fi
+
+COMMIT_DATE=$(git -C "${SITK_SRC}" log -1 --format=%cs 2>/dev/null || true)
+if [ -z "${COMMIT_DATE}" ]; then
+    COMMIT_DATE=$(date +%Y-%m-%d)
+fi
+
+echo "Setting Version to ${R_VERSION}"
+echo "Setting Date to ${COMMIT_DATE}"
+tmp=$(mktemp)
+sed "s/^Version:.*/Version: ${R_VERSION}/" "${DESCRIPTION}" > "${tmp}" && mv "${tmp}" "${DESCRIPTION}"
+tmp=$(mktemp)
+sed "s/^Date:.*/Date: ${COMMIT_DATE}/" "${DESCRIPTION}" > "${tmp}" && mv "${tmp}" "${DESCRIPTION}"
+echo "Done. DESCRIPTION updated."


### PR DESCRIPTION
Add an entry to the DESCRIPTION that indicates the committish we want to use to build the package. Then run the sitk_r_version_date.sh script to derive the version and date from the committish and patch the DESCRIPTION file accordingly. This allows us to build the R package for any arbitrary version of SimpleITK, including development versions that do not have an official release tag.

Because the Version field in the DESCIPTION file expects a specific format it may not match an official release version so the closest version is computed. For example, if the target is a hash that appears after release 2.5.3 but before 2.5.4 then it will be assigned version 2.5.4.9000 with the date of the commit. If it is a tag from an official release (vMAJOR.MINOR.PATCH)then that version is used directly. All tags with trailing non numeric characters will be treated as development versions. That means 3.0.0a1, 3.0.0a2 will both be assigned version 3.0.0.9000 with the date of the commit.

The 9000 suffix denotes "in development" in the R universe, see https://r-pkgs.org/lifecycle.html#dev-version.