### PR TITLE
Update tested R versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ workflows:
       - r-build:
           matrix:
             parameters:
-              r-version: ['4.3.1', '4.4.1']
+              r-version: ['4.3.3', '4.4.3', '4.5.3']
               os: ["macos-arm"]
           filters:
             branches:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        R: [ '4.3.1', '4.4.1' ]
+        R: [ '4.3.3', '4.5.3' ]
         os: [ 'macos-15-intel', 'ubuntu-latest', 'windows-latest']
-        exclude:
-          - R: '4.3.1'
-            os: 'windows-latest'
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.R }} ${{ matrix.os }} build
     env:


### PR DESCRIPTION
On CircleCI test R versions 4.3.3, 4.4.3, and
4.5.3 on macOS ARM (about 30min per test so we can run all three versions). On GitHub Actions test R versions 4.3.3 and 4.5.3 on macOS-intel, Ubuntu, and Windows (several hours per test so only test oldest and newest).