### PR TITLE
Harmonize installation across OSes.

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -102,7 +102,7 @@ export MAKEJ
   # Remove ITK-build to save space (if present)
   [ -d ITK-build ] && rm -rf ITK-build
 
-  # Move wrapped R package into the package root
-  # TODO: sitkmove.R fails to move for Windows
-  cp -r SimpleITK-build/Wrapping/R/Packaging/SimpleITK/* "$PKGBASED/."
+  # Use R to do the move to avoid system specific issues.
+  ${RCALL} -f ${PKGBASED}/sitkmove.R --args SimpleITK-build/Wrapping/R/Packaging/SimpleITK/ ${PKGBASED} ||
+  exit 1
 )

--- a/sitkmove.R
+++ b/sitkmove.R
@@ -3,13 +3,34 @@ movestuff <- function(builddir, destdir)
     pkgstuff <- list.files(path=builddir, full.names=TRUE)
     bn <- basename(pkgstuff)
     fulldest <- file.path(destdir, bn)
-    file.rename(from=pkgstuff, to=fulldest)
+    # On non windows platforms cross drive renaming works but not on windows
+    if (.Platform$OS.type != "windows") {
+        moved <- file.rename(from=pkgstuff, to=fulldest)
+        # If not all files were moved, undo those that were and report an error
+        if (!all(moved)) {
+            file.rename(from=fulldest[moved], to=pkgstuff[moved])
+            message("ERROR: failed to move (destination full?): ", paste(pkgstuff[!moved], collapse=", "))
+            return(1L)
+        }
+        return(0L)
+    }
+    else { # Windows, copy and delete
+        copied <- file.copy(from=pkgstuff, to=fulldest, recursive=TRUE)
+        if (all(copied)) {
+            unlink(pkgstuff[copied], recursive=TRUE)
+        # If not all files were copied, undo those that were and report an error
+        } else {
+            unlink(fulldest[copied], recursive=TRUE)
+            message("ERROR: failed to move (destination full?): ", paste(pkgstuff[!copied], collapse=", "))
+            return(1L)
+        }
+        return(0L)
+    }
 }
 
 args <- commandArgs( TRUE )
 src <- args[[1]]
 dest <- args[[2]]
 
-movestuff(src, dest)
-q(save="no")
+quit(save="no", status=movestuff(src, dest))
 


### PR DESCRIPTION
Use the sitkmove.R script to install the package
on all OSes. On Windows, the build directory is
C:/bld and the install directory may be on another drive which required modifying the sitkMover.R script
to deal with cross drive move.