### PR TITLE
WIP: Test R 4.6.0 with SWIG patch branch from blowekamp fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        R: [ '4.4.3', '4.5.3' ]
+        R: [ '4.4.3', '4.5.3', '4.6.0' ]
         os: [ 'macos-15-intel', 'ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.R }} ${{ matrix.os }} build

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: SimpleITK
-SITK_TARGET: v2.5.4
+SITK_TARGET: release
 Note1: The Version and Date fields are derived from the SITK_TARGET 
        DO NOT EDIT THEM MANUALLY. 
        After updating the SITK_TARGET run the sitk_r_version_date.sh script

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ export RCALL
 CC="$(${RCALL} CMD config CC)"
 CXX="$(${RCALL} CMD config CXX)"
 CFLAGS="$(${RCALL} CMD config CFLAGS)"
-CXXFLAGS="$(${RCALL} CMD config CXX11FLAGS)"
+CXXFLAGS="$(${RCALL} CMD config CXXFLAGS)"
 CPPFLAGS="$(${RCALL} CMD config CPPFLAGS)"
 export CXX
 export CC

--- a/configure.win
+++ b/configure.win
@@ -51,7 +51,7 @@ mkdir -p "$BUILDDIR"
 CC="$("${R_HOME}/bin/R.exe" CMD config CC)"
 CXX="$("${R_HOME}/bin/R.exe" CMD config CXX)"
 CFLAGS="$("${R_HOME}/bin/R.exe" CMD config CFLAGS)"
-CXXFLAGS="$("${R_HOME}/bin/R.exe" CMD config CXX11FLAGS)"
+CXXFLAGS="$("${R_HOME}/bin/R.exe" CMD config CXXFLAGS)"
 CPPFLAGS="$("${R_HOME}/bin/R.exe" CMD config CPPFLAGS)"
 export CC CXX CFLAGS CXXFLAGS CPPFLAGS
 


### PR DESCRIPTION
This is a WIP PR to verify the R 4.6.0 compatibility fix works end-to-end.

### Changes
- `DESCRIPTION`: point `SITK_TARGET` at `superbuild_patch_swig_for_r` branch on the `blowekamp` fork of SimpleITK (see SimpleITK/SimpleITK#2587)
- `DESCRIPTION`: use `https://github.com/blowekamp/SimpleITK` as the source URL so the `configure` script clones the patched fork
- `.github/workflows/main.yml`: add `4.6.0` to the R version matrix

Once the upstream PRs (SimpleITK/SimpleITK#2587 / #2588) are merged, this PR should be updated to point back at the upstream repo and a released tag.