### PR TITLE
SimpleITK 2.5.5 with R 4.6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        R: [ '4.4.3', '4.5.3' ]
+        R: [ '4.4.3', '4.5.3', '4.6.0' ]
         os: [ 'macos-15-intel', 'ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.R }} ${{ matrix.os }} build

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: SimpleITK
-SITK_TARGET: v2.5.4
+SITK_TARGET: v2.5.5
 Note1: The Version and Date fields are derived from the SITK_TARGET 
        DO NOT EDIT THEM MANUALLY. 
        After updating the SITK_TARGET run the sitk_r_version_date.sh script
        and it will update these fields according to the SITK_TARGET.
-Version: 2.5.4
-Date: 2026-04-22
+Version: 2.5.5
+Date: 2026-05-12
 Title: SimpleITK: A Simplified Interface to the Insight Toolkit
 Authors@R: c(person("Richard", "Beare", role = c("aut", "cre"),
                       email = "Richard.Beare@ieee.org"),
@@ -14,7 +14,7 @@ Authors@R: c(person("Richard", "Beare", role = c("aut", "cre"),
 		     person("Ziv", "Yaniv", role="aut",
 		     email = "zivyaniv@nih.gov"))
 Author: Richard Beare, Bradley Lowekamp, Ziv Yaniv plus loads of others
-Depends: R (>= 3.4)
+Depends: R (>= 4.0)
 Imports: methods,
          desc
 Description: This package is an interface to SimpleITK, which is a simplified

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ export RCALL
 CC="$(${RCALL} CMD config CC)"
 CXX="$(${RCALL} CMD config CXX)"
 CFLAGS="$(${RCALL} CMD config CFLAGS)"
-CXXFLAGS="$(${RCALL} CMD config CXX11FLAGS)"
+CXXFLAGS="$(${RCALL} CMD config CXXFLAGS)"
 CPPFLAGS="$(${RCALL} CMD config CPPFLAGS)"
 export CXX
 export CC

--- a/configure.win
+++ b/configure.win
@@ -51,7 +51,7 @@ mkdir -p "$BUILDDIR"
 CC="$("${R_HOME}/bin/R.exe" CMD config CC)"
 CXX="$("${R_HOME}/bin/R.exe" CMD config CXX)"
 CFLAGS="$("${R_HOME}/bin/R.exe" CMD config CFLAGS)"
-CXXFLAGS="$("${R_HOME}/bin/R.exe" CMD config CXX11FLAGS)"
+CXXFLAGS="$("${R_HOME}/bin/R.exe" CMD config CXXFLAGS)"
 CPPFLAGS="$("${R_HOME}/bin/R.exe" CMD config CPPFLAGS)"
 export CC CXX CFLAGS CXXFLAGS CPPFLAGS
 


### PR DESCRIPTION
Update the SimpleITK version to 2.5.5.

Adds R 4.6.0 testing.