### PR TITLE
Address error with hombrew install of rig.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,7 @@ jobs:
             R_VERSION="<< parameters.r-version >>"
             # Install rig, R Installation Manager (https://github.com/r-lib/rig) to control installed R version
             if [ "$RUNNER_OS" == "macos" ]; then
-              brew tap r-lib/rig
-              brew install --cask rig
+              brew install --cask r-lib/rig/rig
               rig add $R_VERSION
               # on macOS the R package is installed into a MAJOR.MINOR directory
               # the PATCH is ignored (only one patch version supported) the


### PR DESCRIPTION
New trust policy for homebrew casks (https://docs.brew.sh/Tap-Trust) causes rig installation to fail with the following error: Error: Refusing to load cask r-lib/rig/rig from untrusted tap r-lib/rig. Run `brew trust --cask r-lib/rig/rig` or `brew trust r-lib/rig` to trust it.

This change in the installation process addresses
the error by directly installing the rig cask without tapping the repository first, which avoids the trust issue.